### PR TITLE
fix var def with "var xxx = yyy"

### DIFF
--- a/ob-elvish.el
+++ b/ob-elvish.el
@@ -80,7 +80,7 @@ Optional argument PROCESSED-PARAMS may contain PARAMS preprocessed by ‘org-bab
      "\n"
      (mapconcat ;; define any variables
       (lambda (pair)
-        (format "%s = %s"
+        (format "var %s = %s"
                 (car pair) (ob-elvish-var-to-elvish (cdr pair))))
       vars "\n") "\n" body "\n")))
 


### PR DESCRIPTION
in elvish, now we need to use var xxx = yyy format to define a var